### PR TITLE
Fix for Anyone Delete

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -12,6 +12,7 @@ Config.UseDataBase = true
 
 -- USE ONLY ONE OF THE BELOW --
 Config.AllowAnyoneToEdit = true -- True or False
+Config.AllowAnyoneToDelete = true -- True or False
 Config.AdminLock = false -- Use 'false' for no admin lock or IE group names. {'admin', 'god'}
 Config.JobLock = false --{'police', 'doctor'} -- Use 'false' for no job lock or IE. {'police'}
 -------------------------------


### PR DESCRIPTION
At an update at some point the client uses anyone can edit. While the server.lua uses anyone can delete. 

Only anyone could edit true/false was in the config. So by adding the anyone can delete to the config it fixes the bug where it wasn't allowing folks to delete scenes.