### PR TITLE
a little change for an annoying message

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -122,8 +122,6 @@ if Config.HotKeysEnabled then
             if whenKeyJustPressed(Config.HotKeys.Place) then
                 if addMode then
                     TriggerEvent("bcc_scene:start")
-                else
-                    Notify(Config.Texts.SceneErr)
                 end
             end
         end

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -24,4 +24,4 @@ files {
 
 ui_page 'ui/index.html'
 
-version '2.2.3'
+version '2.2.4'


### PR DESCRIPTION
# main.lua
Removed the annoying message triggered by pressing 'J' to call my wagon 📃 when not in an active scene.
